### PR TITLE
Handle CORs preflight

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -11,6 +11,11 @@ module FireHelpAPI
     # Initialize configuration defaults for originally generated Rails version.
     config.load_defaults 5.1
 
+    config.action_dispatch.default_headers = {
+      'Access-Control-Allow-Origin' => '*',
+      'Access-Control-Request-Method' => %w{GET POST OPTIONS}.join(",")
+    }
+
     config.middleware.insert_before 0, Rack::Cors do
       allow do
         origins '*'


### PR DESCRIPTION
https://stackoverflow.com/questions/43871637/no-access-control-allow-origin-header-is-present-on-the-requested-resource-whe

## Reasoning
Apparently, certain header attributes (ex. `content-type: application/json`) trigger a CORs preflight request.
  * CORs preflight is an automatic, preliminary request made to check if the server is set up to receive cross-origin requests
  * The PR has the server explicitly respond to the CORs preflight
  * The possible solution was found here https://demisx.github.io/rails-api/2014/02/18/configure-accept-headers-cors.html